### PR TITLE
Replace "adoption" terminology with "utilization"

### DIFF
--- a/client/components/AnalyticsDashboard.tsx
+++ b/client/components/AnalyticsDashboard.tsx
@@ -148,7 +148,7 @@ const topTemplates = [
     interviews: 156,
     interviewChange: 18.2,
     effectiveness: 91.4,
-    adoptionRate: 68.2,
+    utilizationRate: 68.2,
     integrity: 91.2,
     performance: 'up'
   },
@@ -157,7 +157,7 @@ const topTemplates = [
     interviews: 132,
     interviewChange: 12.1,
     effectiveness: 94.8,
-    adoptionRate: 72.1,
+    utilizationRate: 72.1,
     integrity: 93.8,
     performance: 'up'
   },
@@ -166,7 +166,7 @@ const topTemplates = [
     interviews: 94,
     interviewChange: -5.3,
     effectiveness: 87.3,
-    adoptionRate: 64.9,
+    utilizationRate: 64.9,
     integrity: 88.6,
     performance: 'down'
   }
@@ -476,7 +476,7 @@ export default function AnalyticsDashboard() {
                   <th className="text-left py-3 px-2 font-medium text-foreground">Template</th>
                   <th className="text-left py-3 px-2 font-medium text-foreground">Interviews</th>
                   <th className="text-left py-3 px-2 font-medium text-foreground">Effectiveness</th>
-                <th className="text-left py-3 px-2 font-medium text-foreground">Adoption Rate</th>
+                <th className="text-left py-3 px-2 font-medium text-foreground">Utilization Rate</th>
                   <th className="text-left py-3 px-2 font-medium text-foreground">Performance</th>
                 </tr>
               </thead>
@@ -495,7 +495,7 @@ export default function AnalyticsDashboard() {
                       <div className="font-medium text-foreground">{template.effectiveness}%</div>
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{template.adoptionRate}%</div>
+                      <div className="font-medium text-foreground">{template.utilizationRate}%</div>
                     </td>
                     <td className="py-3 px-2">
                       {template.performance === 'up' ? (

--- a/client/components/AnalyticsDashboard.tsx
+++ b/client/components/AnalyticsDashboard.tsx
@@ -1,28 +1,28 @@
-import { useState } from 'react';
-import { 
-  TrendingUp, 
-  TrendingDown, 
-  Minus, 
-  Users, 
-  CheckCircle2, 
-  Clock, 
-  Shield, 
-  Brain, 
+import { useState } from "react";
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Users,
+  CheckCircle2,
+  Clock,
+  Shield,
+  Brain,
   Award,
   AlertTriangle,
   Plus,
   Calendar,
   FileText,
   Bell,
-  Download
-} from 'lucide-react';
-import { 
-  AreaChart, 
-  Area, 
-  XAxis, 
-  YAxis, 
-  CartesianGrid, 
-  Tooltip, 
+  Download,
+} from "lucide-react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
   ResponsiveContainer,
   PieChart,
   Pie,
@@ -34,195 +34,197 @@ import {
   Radar,
   FunnelChart,
   Funnel,
-  LabelList
-} from 'recharts';
+  LabelList,
+} from "recharts";
 
 // Mock data for the dashboard
 const kpiData = [
   {
-    title: 'Total Interviews Scheduled',
-    value: '1,247',
+    title: "Total Interviews Scheduled",
+    value: "1,247",
     change: 12.5,
-    icon: Calendar
+    icon: Calendar,
   },
   {
-    title: 'Cancelled Interviews',
-    value: '78',
+    title: "Cancelled Interviews",
+    value: "78",
     change: -8.4,
-    icon: AlertTriangle
+    icon: AlertTriangle,
   },
   {
-    title: 'Total Interviews Completed',
-    value: '1,089',
+    title: "Total Interviews Completed",
+    value: "1,089",
     change: 8.3,
-    icon: CheckCircle2
+    icon: CheckCircle2,
   },
   {
-    title: 'Pending Evaluations',
-    value: '158',
+    title: "Pending Evaluations",
+    value: "158",
     change: -5.2,
-    icon: Clock
-  }
+    icon: Clock,
+  },
 ];
 
 const recommendationData = [
-  { title: 'Highly Recommended', count: 342, percentage: 31.4, change: 8.2 },
-  { title: 'Recommended', count: 287, percentage: 26.3, change: 3.5 },
-  { title: 'Consider', count: 199, percentage: 18.3, change: -2.1 },
-  { title: 'Not Recommended', count: 261, percentage: 24.0, change: -12.3 }
+  { title: "Highly Recommended", count: 342, percentage: 31.4, change: 8.2 },
+  { title: "Recommended", count: 287, percentage: 26.3, change: 3.5 },
+  { title: "Consider", count: 199, percentage: 18.3, change: -2.1 },
+  { title: "Not Recommended", count: 261, percentage: 24.0, change: -12.3 },
 ];
 
 const funnelData = [
-  { name: 'Scheduled', value: 1247, fill: '#8884d8' },
-  { name: 'Cancelled', value: 78, fill: '#ff6b6b' },
-  { name: 'Interviewed', value: 1089, fill: '#8dd1e1' },
-  { name: 'Evaluated', value: 892, fill: '#82ca9d' },
-  { name: 'Recommended', value: 342, fill: '#ffc658' }
+  { name: "Scheduled", value: 1247, fill: "#8884d8" },
+  { name: "Cancelled", value: 78, fill: "#ff6b6b" },
+  { name: "Interviewed", value: 1089, fill: "#8dd1e1" },
+  { name: "Evaluated", value: 892, fill: "#82ca9d" },
+  { name: "Recommended", value: 342, fill: "#ffc658" },
 ];
 
 const outcomeData = [
-  { month: 'Jan', recommended: 45, consider: 38, rejected: 17 },
-  { month: 'Feb', recommended: 52, consider: 35, rejected: 13 },
-  { month: 'Mar', recommended: 48, consider: 42, rejected: 10 },
-  { month: 'Apr', recommended: 61, consider: 29, rejected: 10 },
-  { month: 'May', recommended: 58, consider: 33, rejected: 9 },
-  { month: 'Jun', recommended: 65, consider: 28, rejected: 7 }
+  { month: "Jan", recommended: 45, consider: 38, rejected: 17 },
+  { month: "Feb", recommended: 52, consider: 35, rejected: 13 },
+  { month: "Mar", recommended: 48, consider: 42, rejected: 10 },
+  { month: "Apr", recommended: 61, consider: 29, rejected: 10 },
+  { month: "May", recommended: 58, consider: 33, rejected: 9 },
+  { month: "Jun", recommended: 65, consider: 28, rejected: 7 },
 ];
 
 const violationData = [
-  { name: 'Lip-sync Detected', value: 12, color: '#ff6b6b' },
-  { name: 'Long Silence', value: 28, color: '#4ecdc4' },
-  { name: 'Tab Switching', value: 45, color: '#45b7d1' },
-  { name: 'Other Device Detected', value: 18, color: '#96ceb4' },
-  { name: 'Looking Away Repeatedly', value: 22, color: '#f39c12' }
+  { name: "Lip-sync Detected", value: 12, color: "#ff6b6b" },
+  { name: "Long Silence", value: 28, color: "#4ecdc4" },
+  { name: "Tab Switching", value: 45, color: "#45b7d1" },
+  { name: "Other Device Detected", value: 18, color: "#96ceb4" },
+  { name: "Looking Away Repeatedly", value: 22, color: "#f39c12" },
 ];
 
 const competencyData = [
-  { competency: 'Technical Skills', actual: 85, expected: 80 },
-  { competency: 'Communication', actual: 78, expected: 85 },
-  { competency: 'Problem Solving', actual: 82, expected: 78 },
-  { competency: 'Leadership', actual: 75, expected: 82 },
-  { competency: 'Adaptability', actual: 88, expected: 80 },
-  { competency: 'Team Collaboration', actual: 80, expected: 85 }
+  { competency: "Technical Skills", actual: 85, expected: 80 },
+  { competency: "Communication", actual: 78, expected: 85 },
+  { competency: "Problem Solving", actual: 82, expected: 78 },
+  { competency: "Leadership", actual: 75, expected: 82 },
+  { competency: "Adaptability", actual: 88, expected: 80 },
+  { competency: "Team Collaboration", actual: 80, expected: 85 },
 ];
 
 const topInterviewers = [
   {
-    name: 'Sarah Johnson',
+    name: "Sarah Johnson",
     interviews: 89,
     interviewChange: 12.3,
-    avgEvalTime: '45m',
+    avgEvalTime: "45m",
     timeChange: -8.2,
     aiAlignment: 94.2,
     alignmentChange: 3.1,
     missedElements: 2,
-    avgScore: 87.4
+    avgScore: 87.4,
   },
   {
-    name: 'Michael Chen',
+    name: "Michael Chen",
     interviews: 76,
     interviewChange: 8.9,
-    avgEvalTime: '52m',
+    avgEvalTime: "52m",
     timeChange: 5.1,
     aiAlignment: 91.8,
     alignmentChange: 1.4,
     missedElements: 1,
-    avgScore: 89.2
+    avgScore: 89.2,
   },
   {
-    name: 'Emily Rodriguez',
+    name: "Emily Rodriguez",
     interviews: 82,
     interviewChange: -2.1,
-    avgEvalTime: '38m',
+    avgEvalTime: "38m",
     timeChange: -12.4,
     aiAlignment: 89.5,
     alignmentChange: -1.8,
     missedElements: 3,
-    avgScore: 84.7
-  }
+    avgScore: 84.7,
+  },
 ];
 
 const topTemplates = [
   {
-    name: 'Senior Software Engineer',
+    name: "Senior Software Engineer",
     interviews: 156,
     interviewChange: 18.2,
     effectiveness: 91.4,
     utilizationRate: 68.2,
     integrity: 91.2,
-    performance: 'up'
+    performance: "up",
   },
   {
-    name: 'Product Manager',
+    name: "Product Manager",
     interviews: 132,
     interviewChange: 12.1,
     effectiveness: 94.8,
     utilizationRate: 72.1,
     integrity: 93.8,
-    performance: 'up'
+    performance: "up",
   },
   {
-    name: 'Data Scientist',
+    name: "Data Scientist",
     interviews: 94,
     interviewChange: -5.3,
     effectiveness: 87.3,
     utilizationRate: 64.9,
     integrity: 88.6,
-    performance: 'down'
-  }
+    performance: "down",
+  },
 ];
 
 const recentAlerts = [
   {
-    type: 'warning',
-    message: 'Template "Product Manager V1" has highest not recommended rate (45%)',
-    time: '2 hours ago',
-    icon: AlertTriangle
+    type: "warning",
+    message:
+      'Template "Product Manager V1" has highest not recommended rate (45%)',
+    time: "2 hours ago",
+    icon: AlertTriangle,
   },
   {
-    type: 'success',
+    type: "success",
     message: 'Template "Frontend Developer" updated successfully',
-    time: '6 hours ago',
-    icon: CheckCircle2
+    time: "6 hours ago",
+    icon: CheckCircle2,
   },
   {
-    type: 'warning',
-    message: 'Template "Data Scientist V2" showing increased rejection trend (38%)',
-    time: '1 day ago',
-    icon: AlertTriangle
-  }
+    type: "warning",
+    message:
+      'Template "Data Scientist V2" showing increased rejection trend (38%)',
+    time: "1 day ago",
+    icon: AlertTriangle,
+  },
 ];
 
 // Upcoming interviews data
 const upcomingInterviews = [
   {
-    candidate: 'Alex Thompson',
-    role: 'Senior Frontend Developer',
-    interviewer: 'Sarah Johnson',
-    time: 'Today, 2:30 PM',
-    status: 'confirmed'
+    candidate: "Alex Thompson",
+    role: "Senior Frontend Developer",
+    interviewer: "Sarah Johnson",
+    time: "Today, 2:30 PM",
+    status: "confirmed",
   },
   {
-    candidate: 'Maria Lopez',
-    role: 'Product Manager',
-    interviewer: 'Michael Chen',
-    time: 'Today, 4:00 PM',
-    status: 'confirmed'
+    candidate: "Maria Lopez",
+    role: "Product Manager",
+    interviewer: "Michael Chen",
+    time: "Today, 4:00 PM",
+    status: "confirmed",
   },
   {
-    candidate: 'David Kim',
-    role: 'Data Scientist',
-    interviewer: 'Emily Rodriguez',
-    time: 'Tomorrow, 10:00 AM',
-    status: 'pending'
+    candidate: "David Kim",
+    role: "Data Scientist",
+    interviewer: "Emily Rodriguez",
+    time: "Tomorrow, 10:00 AM",
+    status: "pending",
   },
   {
-    candidate: 'Lisa Wang',
-    role: 'UX Designer',
-    interviewer: 'Sarah Johnson',
-    time: 'Tomorrow, 3:00 PM',
-    status: 'confirmed'
-  }
+    candidate: "Lisa Wang",
+    role: "UX Designer",
+    interviewer: "Sarah Johnson",
+    time: "Tomorrow, 3:00 PM",
+    status: "confirmed",
+  },
 ];
 
 const ChangeIndicator = ({ value }: { value: number }) => {
@@ -251,15 +253,19 @@ const ChangeIndicator = ({ value }: { value: number }) => {
 };
 
 export default function AnalyticsDashboard() {
-  const [timePeriod, setTimePeriod] = useState('30d');
+  const [timePeriod, setTimePeriod] = useState("30d");
 
   return (
     <div className="space-y-8">
       {/* Header */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold text-foreground">Interview Analytics Dashboard</h1>
-          <p className="text-muted-foreground">Real-time insights and performance metrics</p>
+          <h1 className="text-3xl font-bold text-foreground">
+            Interview Analytics Dashboard
+          </h1>
+          <p className="text-muted-foreground">
+            Real-time insights and performance metrics
+          </p>
         </div>
         <div className="flex items-center space-x-3">
           <input
@@ -284,13 +290,18 @@ export default function AnalyticsDashboard() {
         {kpiData.map((kpi, index) => {
           const Icon = kpi.icon;
           return (
-            <div key={index} className="bg-card border border-border rounded-xl p-6">
+            <div
+              key={index}
+              className="bg-card border border-border rounded-xl p-6"
+            >
               <div className="flex items-center justify-between mb-2">
                 <Icon className="w-5 h-5 text-primary" />
                 <ChangeIndicator value={kpi.change} />
               </div>
               <div className="space-y-1">
-                <p className="text-2xl font-bold text-foreground">{kpi.value}</p>
+                <p className="text-2xl font-bold text-foreground">
+                  {kpi.value}
+                </p>
                 <p className="text-sm text-muted-foreground">{kpi.title}</p>
               </div>
             </div>
@@ -302,17 +313,30 @@ export default function AnalyticsDashboard() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Upcoming Interviews */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">Upcoming Interviews</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            Upcoming Interviews
+          </h3>
           <div className="space-y-4">
             {upcomingInterviews.map((interview, index) => (
-              <div key={index} className="flex items-center justify-between p-4 bg-muted rounded-lg">
+              <div
+                key={index}
+                className="flex items-center justify-between p-4 bg-muted rounded-lg"
+              >
                 <div className="flex-1">
-                  <div className="font-medium text-foreground">{interview.candidate}</div>
-                  <div className="text-sm text-muted-foreground">{interview.role}</div>
-                  <div className="text-sm text-muted-foreground">with {interview.interviewer}</div>
+                  <div className="font-medium text-foreground">
+                    {interview.candidate}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {interview.role}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    with {interview.interviewer}
+                  </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-sm font-medium text-foreground">{interview.time}</div>
+                  <div className="text-sm font-medium text-foreground">
+                    {interview.time}
+                  </div>
                 </div>
               </div>
             ))}
@@ -321,15 +345,26 @@ export default function AnalyticsDashboard() {
 
         {/* Recommendation Summary */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">Recommendation Summary</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            Recommendation Summary
+          </h3>
           <div className="grid grid-cols-1 gap-4">
             {recommendationData.map((item, index) => (
-              <div key={index} className="flex items-center justify-between p-4 bg-muted rounded-lg">
+              <div
+                key={index}
+                className="flex items-center justify-between p-4 bg-muted rounded-lg"
+              >
                 <div className="flex items-center space-x-3">
-                  <div className="text-2xl font-bold text-foreground">{item.count}</div>
+                  <div className="text-2xl font-bold text-foreground">
+                    {item.count}
+                  </div>
                   <div>
-                    <div className="font-medium text-foreground">{item.title}</div>
-                    <div className="text-sm text-muted-foreground">{item.percentage}% of total</div>
+                    <div className="font-medium text-foreground">
+                      {item.title}
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {item.percentage}% of total
+                    </div>
                   </div>
                 </div>
                 <ChangeIndicator value={item.change} />
@@ -344,7 +379,9 @@ export default function AnalyticsDashboard() {
         {/* Interview Funnel */}
         <div className="bg-card border border-border rounded-xl p-6">
           <div className="flex items-center justify-between mb-6">
-            <h3 className="text-lg font-semibold text-foreground">Interview Funnel</h3>
+            <h3 className="text-lg font-semibold text-foreground">
+              Interview Funnel
+            </h3>
             <div className="text-sm text-muted-foreground">
               Conversion Rate: 11.0% <ChangeIndicator value={2.3} />
             </div>
@@ -352,11 +389,7 @@ export default function AnalyticsDashboard() {
           <ResponsiveContainer width="100%" height={300}>
             <FunnelChart>
               <Tooltip />
-              <Funnel
-                dataKey="value"
-                data={funnelData}
-                isAnimationActive
-              >
+              <Funnel dataKey="value" data={funnelData} isAnimationActive>
                 <LabelList position="center" fill="#fff" stroke="none" />
               </Funnel>
             </FunnelChart>
@@ -365,7 +398,9 @@ export default function AnalyticsDashboard() {
 
         {/* Session Integrity Violations */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">Session Integrity Violations</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            Session Integrity Violations
+          </h3>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
               <Pie
@@ -375,7 +410,9 @@ export default function AnalyticsDashboard() {
                 outerRadius={80}
                 fill="#8884d8"
                 dataKey="value"
-                label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                label={({ name, percent }) =>
+                  `${name} ${(percent * 100).toFixed(0)}%`
+                }
               >
                 {violationData.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={entry.color} />
@@ -391,30 +428,64 @@ export default function AnalyticsDashboard() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Interview Outcome Trends */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">Interview Outcome Trends</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            Interview Outcome Trends
+          </h3>
           <ResponsiveContainer width="100%" height={300}>
             <AreaChart data={outcomeData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" />
               <YAxis />
               <Tooltip />
-              <Area type="monotone" dataKey="recommended" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
-              <Area type="monotone" dataKey="consider" stackId="1" stroke="#8dd1e1" fill="#8dd1e1" />
-              <Area type="monotone" dataKey="rejected" stackId="1" stroke="#ff6b6b" fill="#ff6b6b" />
+              <Area
+                type="monotone"
+                dataKey="recommended"
+                stackId="1"
+                stroke="#82ca9d"
+                fill="#82ca9d"
+              />
+              <Area
+                type="monotone"
+                dataKey="consider"
+                stackId="1"
+                stroke="#8dd1e1"
+                fill="#8dd1e1"
+              />
+              <Area
+                type="monotone"
+                dataKey="rejected"
+                stackId="1"
+                stroke="#ff6b6b"
+                fill="#ff6b6b"
+              />
             </AreaChart>
           </ResponsiveContainer>
         </div>
 
         {/* Competency Performance */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">Competency Performance vs. Expected</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            Competency Performance vs. Expected
+          </h3>
           <ResponsiveContainer width="100%" height={300}>
             <RadarChart data={competencyData}>
               <PolarGrid />
               <PolarAngleAxis dataKey="competency" />
               <PolarRadiusAxis angle={90} domain={[0, 100]} />
-              <Radar name="Actual" dataKey="actual" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
-              <Radar name="Expected" dataKey="expected" stroke="#82ca9d" fill="#82ca9d" fillOpacity={0.2} />
+              <Radar
+                name="Actual"
+                dataKey="actual"
+                stroke="#8884d8"
+                fill="#8884d8"
+                fillOpacity={0.6}
+              />
+              <Radar
+                name="Expected"
+                dataKey="expected"
+                stroke="#82ca9d"
+                fill="#82ca9d"
+                fillOpacity={0.2}
+              />
               <Tooltip />
             </RadarChart>
           </ResponsiveContainer>
@@ -425,39 +496,63 @@ export default function AnalyticsDashboard() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Top Interviewers Performance */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">Top Interviewers Performance</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            Top Interviewers Performance
+          </h3>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Interviewer</th>
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Interviews</th>
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Avg. Time</th>
-                  <th className="text-left py-3 px-2 font-medium text-foreground">AI Alignment</th>
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Avg Score</th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Interviewer
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Interviews
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Avg. Time
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    AI Alignment
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Avg Score
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {topInterviewers.map((interviewer, index) => (
                   <tr key={index} className="border-b border-border">
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{interviewer.name}</div>
-                      <div className="text-xs text-muted-foreground">{interviewer.missedElements} missed elements</div>
+                      <div className="font-medium text-foreground">
+                        {interviewer.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {interviewer.missedElements} missed elements
+                      </div>
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{interviewer.interviews}</div>
+                      <div className="font-medium text-foreground">
+                        {interviewer.interviews}
+                      </div>
                       <ChangeIndicator value={interviewer.interviewChange} />
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{interviewer.avgEvalTime}</div>
+                      <div className="font-medium text-foreground">
+                        {interviewer.avgEvalTime}
+                      </div>
                       <ChangeIndicator value={interviewer.timeChange} />
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{interviewer.aiAlignment}%</div>
+                      <div className="font-medium text-foreground">
+                        {interviewer.aiAlignment}%
+                      </div>
                       <ChangeIndicator value={interviewer.alignmentChange} />
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{interviewer.avgScore}%</div>
+                      <div className="font-medium text-foreground">
+                        {interviewer.avgScore}%
+                      </div>
                     </td>
                   </tr>
                 ))}
@@ -468,37 +563,59 @@ export default function AnalyticsDashboard() {
 
         {/* High Performing Templates */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">High Performing Templates</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            High Performing Templates
+          </h3>
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Template</th>
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Interviews</th>
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Effectiveness</th>
-                <th className="text-left py-3 px-2 font-medium text-foreground">Utilization Rate</th>
-                  <th className="text-left py-3 px-2 font-medium text-foreground">Performance</th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Template
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Interviews
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Effectiveness
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Utilization Rate
+                  </th>
+                  <th className="text-left py-3 px-2 font-medium text-foreground">
+                    Performance
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {topTemplates.map((template, index) => (
                   <tr key={index} className="border-b border-border">
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{template.name}</div>
-                      <div className="text-xs text-muted-foreground">Integrity: {template.integrity}%</div>
+                      <div className="font-medium text-foreground">
+                        {template.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Integrity: {template.integrity}%
+                      </div>
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{template.interviews}</div>
+                      <div className="font-medium text-foreground">
+                        {template.interviews}
+                      </div>
                       <ChangeIndicator value={template.interviewChange} />
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{template.effectiveness}%</div>
+                      <div className="font-medium text-foreground">
+                        {template.effectiveness}%
+                      </div>
                     </td>
                     <td className="py-3 px-2">
-                      <div className="font-medium text-foreground">{template.utilizationRate}%</div>
+                      <div className="font-medium text-foreground">
+                        {template.utilizationRate}%
+                      </div>
                     </td>
                     <td className="py-3 px-2">
-                      {template.performance === 'up' ? (
+                      {template.performance === "up" ? (
                         <TrendingUp className="w-5 h-5 text-green-600" />
                       ) : (
                         <TrendingDown className="w-5 h-5 text-red-600" />
@@ -517,21 +634,35 @@ export default function AnalyticsDashboard() {
         {/* Recent Alerts & Notifications */}
         <div className="bg-card border border-border rounded-xl p-6">
           <div className="flex items-center justify-between mb-6">
-            <h3 className="text-lg font-semibold text-foreground">Recent Alerts & Notifications</h3>
+            <h3 className="text-lg font-semibold text-foreground">
+              Recent Alerts & Notifications
+            </h3>
             <Bell className="w-5 h-5 text-muted-foreground" />
           </div>
           <div className="space-y-4">
             {recentAlerts.map((alert, index) => {
               const Icon = alert.icon;
               return (
-                <div key={index} className="flex items-start space-x-3 p-3 bg-muted rounded-lg">
-                  <Icon className={`w-5 h-5 mt-0.5 ${
-                    alert.type === 'warning' ? 'text-yellow-500' :
-                    alert.type === 'success' ? 'text-green-500' : 'text-blue-500'
-                  }`} />
+                <div
+                  key={index}
+                  className="flex items-start space-x-3 p-3 bg-muted rounded-lg"
+                >
+                  <Icon
+                    className={`w-5 h-5 mt-0.5 ${
+                      alert.type === "warning"
+                        ? "text-yellow-500"
+                        : alert.type === "success"
+                          ? "text-green-500"
+                          : "text-blue-500"
+                    }`}
+                  />
                   <div className="flex-1">
-                    <p className="text-sm font-medium text-foreground">{alert.message}</p>
-                    <p className="text-xs text-muted-foreground">{alert.time}</p>
+                    <p className="text-sm font-medium text-foreground">
+                      {alert.message}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {alert.time}
+                    </p>
                   </div>
                 </div>
               );
@@ -541,7 +672,9 @@ export default function AnalyticsDashboard() {
 
         {/* Quick Actions */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-6">Quick Actions</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-6">
+            Quick Actions
+          </h3>
           <div className="grid grid-cols-1 gap-3">
             <button className="flex items-center space-x-3 p-4 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors">
               <Plus className="w-5 h-5" />

--- a/client/components/TemplateDetailView.tsx
+++ b/client/components/TemplateDetailView.tsx
@@ -1,11 +1,43 @@
-import { ArrowLeft, Download, Calendar, User, Award, Target, TrendingUp, Users, Brain, BarChart3, Eye } from 'lucide-react';
-import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, PieChart, Pie, Cell, LineChart, Line, RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, FunnelChart, Funnel, LabelList } from 'recharts';
+import {
+  ArrowLeft,
+  Download,
+  Calendar,
+  User,
+  Award,
+  Target,
+  TrendingUp,
+  Users,
+  Brain,
+  BarChart3,
+  Eye,
+} from "lucide-react";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  FunnelChart,
+  Funnel,
+  LabelList,
+} from "recharts";
 
 interface TemplateDetailViewProps {
   template: any;
   onBack: () => void;
 }
-
 
 const trendData = [
   { month: "Jul", evaluated: 15 },
@@ -13,41 +45,78 @@ const trendData = [
   { month: "Sep", evaluated: 28 },
   { month: "Oct", evaluated: 35 },
   { month: "Nov", evaluated: 31 },
-  { month: "Dec", evaluated: 38 }
+  { month: "Dec", evaluated: 38 },
 ];
 
 const competencyTrends = [
-  { competency: "Technical Skills", weight: 90, performance: 82, criticality: "High" },
-  { competency: "Communication", weight: 75, performance: 88, criticality: "Medium" },
-  { competency: "Problem Solving", weight: 85, performance: 79, criticality: "High" },
+  {
+    competency: "Technical Skills",
+    weight: 90,
+    performance: 82,
+    criticality: "High",
+  },
+  {
+    competency: "Communication",
+    weight: 75,
+    performance: 88,
+    criticality: "Medium",
+  },
+  {
+    competency: "Problem Solving",
+    weight: 85,
+    performance: 79,
+    criticality: "High",
+  },
   { competency: "Leadership", weight: 60, performance: 72, criticality: "Low" },
-  { competency: "Cultural Fit", weight: 70, performance: 85, criticality: "Medium" }
+  {
+    competency: "Cultural Fit",
+    weight: 70,
+    performance: 85,
+    criticality: "Medium",
+  },
 ];
 
 const funnelData = [
   { name: "Scheduled", value: 234, fill: "#8b5cf6" },
   { name: "Interviewed", value: 198, fill: "#7c3aed" },
   { name: "Cancelled", value: 36, fill: "#ef4444" },
-  { name: "Evaluated", value: 178, fill: "#6d28d9" }
+  { name: "Evaluated", value: 178, fill: "#6d28d9" },
 ];
 
 const topQuestions = [
-  { question: "Describe your approach to system design", skillCovered: "System Architecture" },
-  { question: "How do you handle technical debt?", skillCovered: "Code Quality Management" },
-  { question: "Walk through a challenging bug you fixed", skillCovered: "Problem Solving" },
-  { question: "Explain your testing strategy", skillCovered: "Quality Assurance" },
-  { question: "How do you optimize database queries?", skillCovered: "Database Optimization" }
+  {
+    question: "Describe your approach to system design",
+    skillCovered: "System Architecture",
+  },
+  {
+    question: "How do you handle technical debt?",
+    skillCovered: "Code Quality Management",
+  },
+  {
+    question: "Walk through a challenging bug you fixed",
+    skillCovered: "Problem Solving",
+  },
+  {
+    question: "Explain your testing strategy",
+    skillCovered: "Quality Assurance",
+  },
+  {
+    question: "How do you optimize database queries?",
+    skillCovered: "Database Optimization",
+  },
 ];
 
 const behavioralTraits = [
   { trait: "Confident", percentage: 45, color: "#22c55e" },
   { trait: "Analytical", percentage: 32, color: "#3b82f6" },
   { trait: "Collaborative", percentage: 28, color: "#f59e0b" },
-  { trait: "Innovative", percentage: 25, color: "#8b5cf6" }
+  { trait: "Innovative", percentage: 25, color: "#8b5cf6" },
 ];
 
-
-export default function TemplateDetailView({ template, onBack }: TemplateDetailViewProps) {
+export default function TemplateDetailView({
+  template,
+  onBack,
+}: TemplateDetailViewProps) {
   return (
     <div className="space-y-8">
       {/* Header */}
@@ -62,8 +131,12 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           </button>
           <div className="h-6 w-px bg-border" />
           <div>
-            <h1 className="text-3xl font-bold text-foreground">{template.template}</h1>
-            <p className="text-muted-foreground">{template.department} • {template.role}</p>
+            <h1 className="text-3xl font-bold text-foreground">
+              {template.template}
+            </h1>
+            <p className="text-muted-foreground">
+              {template.department} • {template.role}
+            </p>
           </div>
         </div>
         <div className="flex items-center space-x-2">
@@ -83,7 +156,9 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           </div>
           <div>
             <p className="text-sm text-muted-foreground">Creation Date</p>
-            <p className="font-medium text-foreground">{new Date(template.creationDate).toLocaleDateString()}</p>
+            <p className="font-medium text-foreground">
+              {new Date(template.creationDate).toLocaleDateString()}
+            </p>
           </div>
           <div>
             <p className="text-sm text-muted-foreground">Department</p>
@@ -102,7 +177,9 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           <div className="flex items-center space-x-3">
             <Users className="w-8 h-8 text-blue-500" />
             <div>
-              <p className="text-2xl font-bold text-foreground">{template.interviews}</p>
+              <p className="text-2xl font-bold text-foreground">
+                {template.interviews}
+              </p>
               <p className="text-sm text-muted-foreground">Total Interviews</p>
             </div>
           </div>
@@ -111,7 +188,9 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           <div className="flex items-center space-x-3">
             <TrendingUp className="w-8 h-8 text-green-500" />
             <div>
-              <p className="text-2xl font-bold text-foreground">{template.utilizationRate}%</p>
+              <p className="text-2xl font-bold text-foreground">
+                {template.utilizationRate}%
+              </p>
               <p className="text-sm text-muted-foreground">Utilization Rate</p>
             </div>
           </div>
@@ -120,8 +199,12 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           <div className="flex items-center space-x-3">
             <Award className="w-8 h-8 text-purple-500" />
             <div>
-              <p className="text-2xl font-bold text-foreground">{template.avgCandidateScore}%</p>
-              <p className="text-sm text-muted-foreground">Avg. Candidate Score</p>
+              <p className="text-2xl font-bold text-foreground">
+                {template.avgCandidateScore}%
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Avg. Candidate Score
+              </p>
             </div>
           </div>
         </div>
@@ -129,8 +212,12 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           <div className="flex items-center space-x-3">
             <Eye className="w-8 h-8 text-orange-500" />
             <div>
-              <p className="text-2xl font-bold text-foreground">{template.avgIntegrityScore}%</p>
-              <p className="text-sm text-muted-foreground">Avg. Integrity Score</p>
+              <p className="text-2xl font-bold text-foreground">
+                {template.avgIntegrityScore}%
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Avg. Integrity Score
+              </p>
             </div>
           </div>
         </div>
@@ -138,8 +225,12 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           <div className="flex items-center space-x-3">
             <Brain className="w-8 h-8 text-indigo-500" />
             <div>
-              <p className="text-2xl font-bold text-foreground">{template.effectivenessScore}%</p>
-              <p className="text-sm text-muted-foreground">Effectiveness Score</p>
+              <p className="text-2xl font-bold text-foreground">
+                {template.effectivenessScore}%
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Effectiveness Score
+              </p>
             </div>
           </div>
         </div>
@@ -149,15 +240,30 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Trend Over Time */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Trend Over Time</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-4">
+            Trend Over Time
+          </h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={trendData}>
-                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                <XAxis dataKey="month" stroke="hsl(var(--muted-foreground))" fontSize={12} />
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="hsl(var(--border))"
+                />
+                <XAxis
+                  dataKey="month"
+                  stroke="hsl(var(--muted-foreground))"
+                  fontSize={12}
+                />
                 <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} />
                 <Tooltip />
-                <Line type="monotone" dataKey="evaluated" stroke="#8b5cf6" strokeWidth={2} name="Evaluated" />
+                <Line
+                  type="monotone"
+                  dataKey="evaluated"
+                  stroke="#8b5cf6"
+                  strokeWidth={2}
+                  name="Evaluated"
+                />
               </LineChart>
             </ResponsiveContainer>
           </div>
@@ -165,15 +271,36 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
 
         {/* Competency Weight vs Performance */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Competency Weight vs Performance</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-4">
+            Competency Weight vs Performance
+          </h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart data={competencyTrends}>
                 <PolarGrid />
                 <PolarAngleAxis dataKey="competency" tick={{ fontSize: 10 }} />
-                <PolarRadiusAxis angle={30} domain={[0, 100]} tick={{ fontSize: 8 }} />
-                <Radar name="Weight" dataKey="weight" stroke="#8b5cf6" fill="#8b5cf6" fillOpacity={0.3} strokeWidth={2} />
-                <Radar name="Performance" dataKey="performance" stroke="#22c55e" fill="#22c55e" fillOpacity={0.1} strokeWidth={2} strokeDasharray="5 5" />
+                <PolarRadiusAxis
+                  angle={30}
+                  domain={[0, 100]}
+                  tick={{ fontSize: 8 }}
+                />
+                <Radar
+                  name="Weight"
+                  dataKey="weight"
+                  stroke="#8b5cf6"
+                  fill="#8b5cf6"
+                  fillOpacity={0.3}
+                  strokeWidth={2}
+                />
+                <Radar
+                  name="Performance"
+                  dataKey="performance"
+                  stroke="#22c55e"
+                  fill="#22c55e"
+                  fillOpacity={0.1}
+                  strokeWidth={2}
+                  strokeDasharray="5 5"
+                />
                 <Tooltip />
               </RadarChart>
             </ResponsiveContainer>
@@ -185,7 +312,9 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Interview Funnel */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Interview Funnel</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-4">
+            Interview Funnel
+          </h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <FunnelChart>
@@ -199,18 +328,32 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
         </div>
 
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Competency Criticality Matrix</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-4">
+            Competency Criticality Matrix
+          </h3>
           <div className="space-y-3">
             {competencyTrends.map((comp, index) => (
-              <div key={index} className="flex items-center justify-between p-3 bg-muted rounded-lg">
+              <div
+                key={index}
+                className="flex items-center justify-between p-3 bg-muted rounded-lg"
+              >
                 <div>
-                  <p className="font-medium text-foreground">{comp.competency}</p>
-                  <p className="text-sm text-muted-foreground">Criticality: {comp.criticality}</p>
+                  <p className="font-medium text-foreground">
+                    {comp.competency}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Criticality: {comp.criticality}
+                  </p>
                 </div>
                 <div className="text-right">
-                  <p className="font-medium text-foreground">{comp.performance}%</p>
+                  <p className="font-medium text-foreground">
+                    {comp.performance}%
+                  </p>
                   <div className="w-16 bg-background rounded-full h-2">
-                    <div className="bg-primary h-2 rounded-full" style={{ width: `${comp.performance}%` }} />
+                    <div
+                      className="bg-primary h-2 rounded-full"
+                      style={{ width: `${comp.performance}%` }}
+                    />
                   </div>
                 </div>
               </div>
@@ -223,11 +366,15 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Top 5 Questions */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Top 5 Questions</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-4">
+            Top 5 Questions
+          </h3>
           <div className="space-y-3">
             {topQuestions.map((question, index) => (
               <div key={index} className="p-3 bg-muted rounded-lg">
-                <p className="font-medium text-foreground text-sm mb-2">{question.question}</p>
+                <p className="font-medium text-foreground text-sm mb-2">
+                  {question.question}
+                </p>
                 <span className="px-2 py-1 bg-primary/10 text-primary rounded-full text-xs">
                   {question.skillCovered}
                 </span>
@@ -238,36 +385,52 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
 
         {/* Behavioral Traits & Performance */}
         <div className="bg-card border border-border rounded-xl p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Performance Overview</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-4">
+            Performance Overview
+          </h3>
           <div className="space-y-4 mb-6">
             <div className="p-4 bg-green-500/10 border border-green-500/20 rounded-lg">
               <div className="flex items-center justify-between">
-                <span className="font-medium text-green-700">High Performance</span>
+                <span className="font-medium text-green-700">
+                  High Performance
+                </span>
                 <span className="text-green-600 font-bold">94%</span>
               </div>
-              <p className="text-sm text-green-600 mt-1">Top candidate scores consistently above 90%</p>
+              <p className="text-sm text-green-600 mt-1">
+                Top candidate scores consistently above 90%
+              </p>
             </div>
             <div className="p-4 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
               <div className="flex items-center justify-between">
                 <span className="font-medium text-yellow-700">Skill Gaps</span>
                 <span className="text-yellow-600 font-bold">2 areas</span>
               </div>
-              <p className="text-sm text-yellow-600 mt-1">Technical depth and leadership need improvement</p>
+              <p className="text-sm text-yellow-600 mt-1">
+                Technical depth and leadership need improvement
+              </p>
             </div>
           </div>
 
-          <h4 className="text-md font-semibold text-foreground mb-3">Behavioral Traits</h4>
+          <h4 className="text-md font-semibold text-foreground mb-3">
+            Behavioral Traits
+          </h4>
           <div className="grid grid-cols-2 gap-2">
             {behavioralTraits.map((trait, index) => (
               <div key={index} className="p-2 bg-muted rounded text-center">
-                <div className="text-sm font-bold" style={{ color: trait.color }}>{trait.percentage}%</div>
-                <div className="text-xs text-muted-foreground">{trait.trait}</div>
+                <div
+                  className="text-sm font-bold"
+                  style={{ color: trait.color }}
+                >
+                  {trait.percentage}%
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {trait.trait}
+                </div>
               </div>
             ))}
           </div>
         </div>
       </div>
-
     </div>
   );
 }

--- a/client/components/TemplateDetailView.tsx
+++ b/client/components/TemplateDetailView.tsx
@@ -111,8 +111,8 @@ export default function TemplateDetailView({ template, onBack }: TemplateDetailV
           <div className="flex items-center space-x-3">
             <TrendingUp className="w-8 h-8 text-green-500" />
             <div>
-              <p className="text-2xl font-bold text-foreground">{template.adoptionRate}%</p>
-              <p className="text-sm text-muted-foreground">Adoption Rate</p>
+              <p className="text-2xl font-bold text-foreground">{template.utilizationRate}%</p>
+              <p className="text-sm text-muted-foreground">Utilization Rate</p>
             </div>
           </div>
         </div>

--- a/client/components/TemplateReport.tsx
+++ b/client/components/TemplateReport.tsx
@@ -1,5 +1,15 @@
-import { useState } from 'react';
-import { Search, Filter, Calendar, Users, TrendingUp, Award, Target, Brain, BarChart3 } from 'lucide-react';
+import { useState } from "react";
+import {
+  Search,
+  Filter,
+  Calendar,
+  Users,
+  TrendingUp,
+  Award,
+  Target,
+  Brain,
+  BarChart3,
+} from "lucide-react";
 
 const templateData = [
   {
@@ -20,7 +30,7 @@ const templateData = [
     effectivenessScore: 87,
     success_rate: 75,
     avg_score: 84,
-    time_to_hire: 12
+    time_to_hire: 12,
   },
   {
     id: 2,
@@ -40,7 +50,7 @@ const templateData = [
     effectivenessScore: 89,
     success_rate: 78,
     avg_score: 86,
-    time_to_hire: 15
+    time_to_hire: 15,
   },
   {
     id: 3,
@@ -60,7 +70,7 @@ const templateData = [
     effectivenessScore: 91,
     success_rate: 82,
     avg_score: 88,
-    time_to_hire: 10
+    time_to_hire: 10,
   },
   {
     id: 4,
@@ -80,15 +90,17 @@ const templateData = [
     effectivenessScore: 84,
     success_rate: 72,
     avg_score: 82,
-    time_to_hire: 18
-  }
+    time_to_hire: 18,
+  },
 ];
 
 interface TemplateReportProps {
   onTemplateSelect: (template: any) => void;
 }
 
-export default function TemplateReport({ onTemplateSelect }: TemplateReportProps) {
+export default function TemplateReport({
+  onTemplateSelect,
+}: TemplateReportProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterBy, setFilterBy] = useState("all");
   const [sortBy, setSortBy] = useState("name");
@@ -100,15 +112,21 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
   // Filter and sort templates
   const getFilteredTemplates = () => {
     let filtered = templateData.filter((template) => {
-      const matchesSearch = template.template.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                           template.department.toLowerCase().includes(searchTerm.toLowerCase());
-      
-      const matchesFilter = filterBy === "all" || template.department.toLowerCase() === filterBy.toLowerCase();
-      
-      const matchesDate = dateFilter === "all" || 
-                         (dateFilter === "recent" && new Date(template.creationDate) > new Date('2024-02-01')) ||
-                         (dateFilter === "older" && new Date(template.creationDate) <= new Date('2024-02-01'));
-      
+      const matchesSearch =
+        template.template.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        template.department.toLowerCase().includes(searchTerm.toLowerCase());
+
+      const matchesFilter =
+        filterBy === "all" ||
+        template.department.toLowerCase() === filterBy.toLowerCase();
+
+      const matchesDate =
+        dateFilter === "all" ||
+        (dateFilter === "recent" &&
+          new Date(template.creationDate) > new Date("2024-02-01")) ||
+        (dateFilter === "older" &&
+          new Date(template.creationDate) <= new Date("2024-02-01"));
+
       return matchesSearch && matchesFilter && matchesDate;
     });
 
@@ -119,7 +137,10 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
         case "interviews":
           return b.interviews - a.interviews;
         case "date":
-          return new Date(b.creationDate).getTime() - new Date(a.creationDate).getTime();
+          return (
+            new Date(b.creationDate).getTime() -
+            new Date(a.creationDate).getTime()
+          );
         case "alphabet":
           return a.template.localeCompare(b.template);
         default:
@@ -134,7 +155,7 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
   const totalPages = Math.ceil(filteredTemplates.length / itemsPerPage);
   const paginatedTemplates = filteredTemplates.slice(
     (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
+    currentPage * itemsPerPage,
   );
 
   return (
@@ -143,18 +164,23 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
       <div className="bg-card border border-border rounded-xl p-6">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
           <div>
-            <h3 className="text-lg font-semibold text-foreground">Template Report</h3>
-            <p className="text-sm text-muted-foreground">Interview Template Performance & Analytics</p>
+            <h3 className="text-lg font-semibold text-foreground">
+              Template Report
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Interview Template Performance & Analytics
+            </p>
           </div>
         </div>
       </div>
-
 
       {/* Template List/Cards */}
       <div className="bg-card border border-border rounded-xl p-6">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
           <div>
-            <h3 className="text-lg font-semibold text-foreground">All Templates</h3>
+            <h3 className="text-lg font-semibold text-foreground">
+              All Templates
+            </h3>
           </div>
           <div className="flex flex-col sm:flex-row gap-3">
             <div className="relative">
@@ -199,64 +225,94 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
             </select>
             <div className="flex border border-border rounded-lg">
               <button
-                onClick={() => setViewMode('card')}
-                className={`px-3 py-2 text-sm ${viewMode === 'card' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+                onClick={() => setViewMode("card")}
+                className={`px-3 py-2 text-sm ${viewMode === "card" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"}`}
               >
                 Cards
               </button>
               <button
-                onClick={() => setViewMode('list')}
-                className={`px-3 py-2 text-sm border-l border-border ${viewMode === 'list' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+                onClick={() => setViewMode("list")}
+                className={`px-3 py-2 text-sm border-l border-border ${viewMode === "list" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"}`}
               >
                 List
               </button>
             </div>
           </div>
         </div>
-        
-        {viewMode === 'card' ? (
+
+        {viewMode === "card" ? (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {paginatedTemplates.map((template) => (
-              <div key={template.id} className="bg-card border border-border rounded-xl p-6 hover:shadow-lg hover:border-primary/30 transition-all cursor-pointer" onClick={() => onTemplateSelect(template)}>
+              <div
+                key={template.id}
+                className="bg-card border border-border rounded-xl p-6 hover:shadow-lg hover:border-primary/30 transition-all cursor-pointer"
+                onClick={() => onTemplateSelect(template)}
+              >
                 <div className="flex items-start justify-between mb-4">
                   <div>
-                    <h4 className="font-semibold text-foreground">{template.template}</h4>
-                    <p className="text-sm text-muted-foreground">{template.department} • {template.role}</p>
-                    <p className="text-xs text-muted-foreground">by {template.createdBy}</p>
+                    <h4 className="font-semibold text-foreground">
+                      {template.template}
+                    </h4>
+                    <p className="text-sm text-muted-foreground">
+                      {template.department} • {template.role}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      by {template.createdBy}
+                    </p>
                   </div>
-                  <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-                    template.effectivenessScore >= 85 ? 'bg-green-500/10 text-green-600' :
-                    template.effectivenessScore >= 75 ? 'bg-blue-500/10 text-blue-600' :
-                    'bg-yellow-500/10 text-yellow-600'
-                  }`}>
+                  <span
+                    className={`px-3 py-1 rounded-full text-xs font-medium ${
+                      template.effectivenessScore >= 85
+                        ? "bg-green-500/10 text-green-600"
+                        : template.effectivenessScore >= 75
+                          ? "bg-blue-500/10 text-blue-600"
+                          : "bg-yellow-500/10 text-yellow-600"
+                    }`}
+                  >
                     {template.effectivenessScore}% effective
                   </span>
                 </div>
 
                 <div className="grid grid-cols-2 gap-4 mb-4">
                   <div className="text-center">
-                    <div className="text-lg font-bold text-foreground">{template.interviews}</div>
-                    <div className="text-xs text-muted-foreground">Interviews</div>
+                    <div className="text-lg font-bold text-foreground">
+                      {template.interviews}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Interviews
+                    </div>
                   </div>
                   <div className="text-center">
-                    <div className="text-lg font-bold text-foreground">{template.hired}</div>
+                    <div className="text-lg font-bold text-foreground">
+                      {template.hired}
+                    </div>
                     <div className="text-xs text-muted-foreground">Hired</div>
                   </div>
                 </div>
 
                 <div className="space-y-2">
                   <div className="flex justify-between text-sm">
-                    <span className="text-muted-foreground">Utilization Rate</span>
-                    <span className="font-medium">{template.utilizationRate}%</span>
+                    <span className="text-muted-foreground">
+                      Utilization Rate
+                    </span>
+                    <span className="font-medium">
+                      {template.utilizationRate}%
+                    </span>
                   </div>
                   <div className="w-full bg-background rounded-full h-2">
-                    <div className="bg-primary h-2 rounded-full" style={{ width: `${template.utilizationRate}%` }} />
+                    <div
+                      className="bg-primary h-2 rounded-full"
+                      style={{ width: `${template.utilizationRate}%` }}
+                    />
                   </div>
                 </div>
 
                 <div className="mt-4 pt-4 border-t border-border">
                   <div className="flex justify-between text-xs text-muted-foreground">
-                    <span>Created: {new Date(template.creationDate).toLocaleDateString()}</span>
+                    <span>
+                      Created:{" "}
+                      {new Date(template.creationDate).toLocaleDateString()}
+                    </span>
                     <span>Avg Score: {template.avgCandidateScore}%</span>
                   </div>
                 </div>
@@ -268,32 +324,58 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
             <table className="w-full">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left py-3 px-4 font-medium text-foreground">Template</th>
-                  <th className="text-left py-3 px-4 font-medium text-foreground">Department</th>
-                  <th className="text-left py-3 px-4 font-medium text-foreground">Interviews</th>
-                  <th className="text-left py-3 px-4 font-medium text-foreground">Effectiveness</th>
-                  <th className="text-left py-3 px-4 font-medium text-foreground">Created</th>
+                  <th className="text-left py-3 px-4 font-medium text-foreground">
+                    Template
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium text-foreground">
+                    Department
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium text-foreground">
+                    Interviews
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium text-foreground">
+                    Effectiveness
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium text-foreground">
+                    Created
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {paginatedTemplates.map((template) => (
-                  <tr key={template.id} className="border-b border-border hover:bg-muted/50 cursor-pointer" onClick={() => onTemplateSelect(template)}>
+                  <tr
+                    key={template.id}
+                    className="border-b border-border hover:bg-muted/50 cursor-pointer"
+                    onClick={() => onTemplateSelect(template)}
+                  >
                     <td className="py-3 px-4">
                       <div>
-                        <div className="font-medium text-foreground">{template.template}</div>
-                        <div className="text-sm text-muted-foreground">by {template.createdBy}</div>
+                        <div className="font-medium text-foreground">
+                          {template.template}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          by {template.createdBy}
+                        </div>
                       </div>
                     </td>
                     <td className="py-3 px-4">
-                      <span className="px-2 py-1 bg-secondary rounded-full text-xs">{template.department}</span>
+                      <span className="px-2 py-1 bg-secondary rounded-full text-xs">
+                        {template.department}
+                      </span>
                     </td>
-                    <td className="py-3 px-4 text-muted-foreground">{template.interviews}</td>
+                    <td className="py-3 px-4 text-muted-foreground">
+                      {template.interviews}
+                    </td>
                     <td className="py-3 px-4">
-                      <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                        template.effectivenessScore >= 85 ? 'bg-green-500/10 text-green-500' :
-                        template.effectivenessScore >= 75 ? 'bg-blue-500/10 text-blue-500' :
-                        'bg-yellow-500/10 text-yellow-500'
-                      }`}>
+                      <span
+                        className={`px-2 py-1 rounded-full text-xs font-medium ${
+                          template.effectivenessScore >= 85
+                            ? "bg-green-500/10 text-green-500"
+                            : template.effectivenessScore >= 75
+                              ? "bg-blue-500/10 text-blue-500"
+                              : "bg-yellow-500/10 text-yellow-500"
+                        }`}
+                      >
                         {template.effectivenessScore}%
                       </span>
                     </td>
@@ -311,11 +393,13 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
         {totalPages > 1 && (
           <div className="flex items-center justify-between mt-6">
             <div className="text-sm text-muted-foreground">
-              Showing {((currentPage - 1) * itemsPerPage) + 1} to {Math.min(currentPage * itemsPerPage, filteredTemplates.length)} of {filteredTemplates.length} templates
+              Showing {(currentPage - 1) * itemsPerPage + 1} to{" "}
+              {Math.min(currentPage * itemsPerPage, filteredTemplates.length)}{" "}
+              of {filteredTemplates.length} templates
             </div>
             <div className="flex items-center space-x-2">
               <button
-                onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
+                onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
                 disabled={currentPage === 1}
                 className="px-3 py-2 text-sm bg-secondary hover:bg-secondary/80 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -323,7 +407,8 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
               </button>
               <div className="flex space-x-1">
                 {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
-                  const page = Math.max(1, Math.min(totalPages - 4, currentPage - 2)) + i;
+                  const page =
+                    Math.max(1, Math.min(totalPages - 4, currentPage - 2)) + i;
                   if (page > totalPages) return null;
                   return (
                     <button
@@ -331,8 +416,8 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
                       onClick={() => setCurrentPage(page)}
                       className={`px-3 py-2 text-sm rounded-lg transition-colors ${
                         currentPage === page
-                          ? 'bg-primary text-primary-foreground'
-                          : 'bg-secondary hover:bg-secondary/80'
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-secondary hover:bg-secondary/80"
                       }`}
                     >
                       {page}
@@ -341,7 +426,9 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
                 })}
               </div>
               <button
-                onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
+                onClick={() =>
+                  setCurrentPage((prev) => Math.min(prev + 1, totalPages))
+                }
                 disabled={currentPage === totalPages}
                 className="px-3 py-2 text-sm bg-secondary hover:bg-secondary/80 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >

--- a/client/components/TemplateReport.tsx
+++ b/client/components/TemplateReport.tsx
@@ -13,7 +13,7 @@ const templateData = [
     candidates: 234,
     interviews: 198,
     hired: 67,
-    adoptionRate: 85,
+    utilizationRate: 85,
     avgCandidateScore: 84,
     avgIntegrityScore: 91,
     percentRecommended: 68,
@@ -33,7 +33,7 @@ const templateData = [
     candidates: 156,
     interviews: 134,
     hired: 45,
-    adoptionRate: 92,
+    utilizationRate: 92,
     avgCandidateScore: 86,
     avgIntegrityScore: 89,
     percentRecommended: 72,
@@ -53,7 +53,7 @@ const templateData = [
     candidates: 89,
     interviews: 76,
     hired: 28,
-    adoptionRate: 76,
+    utilizationRate: 76,
     avgCandidateScore: 88,
     avgIntegrityScore: 94,
     percentRecommended: 78,
@@ -73,7 +73,7 @@ const templateData = [
     candidates: 123,
     interviews: 105,
     hired: 38,
-    adoptionRate: 68,
+    utilizationRate: 68,
     avgCandidateScore: 82,
     avgIntegrityScore: 87,
     percentRecommended: 65,
@@ -246,11 +246,11 @@ export default function TemplateReport({ onTemplateSelect }: TemplateReportProps
 
                 <div className="space-y-2">
                   <div className="flex justify-between text-sm">
-                    <span className="text-muted-foreground">Adoption Rate</span>
-                    <span className="font-medium">{template.adoptionRate}%</span>
+                    <span className="text-muted-foreground">Utilization Rate</span>
+                    <span className="font-medium">{template.utilizationRate}%</span>
                   </div>
                   <div className="w-full bg-background rounded-full h-2">
-                    <div className="bg-primary h-2 rounded-full" style={{ width: `${template.adoptionRate}%` }} />
+                    <div className="bg-primary h-2 rounded-full" style={{ width: `${template.utilizationRate}%` }} />
                   </div>
                 </div>
 


### PR DESCRIPTION
## Purpose
Replace all instances of "adoption" and "Adoption rate" terminology with "Utilization" throughout the project to align with updated business terminology and improve clarity of metrics.

## Code changes
- Updated `AnalyticsDashboard.tsx` to use consistent double quotes instead of single quotes for string literals
- Renamed `adoptionRate` property to `utilizationRate` in template data objects
- Updated UI labels from "Adoption Rate" to "Utilization Rate" in template reports
- Applied consistent code formatting and improved readability with proper indentation and spacing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/61704f8df1bb4306a7dcc568105fcd73/orbit-home)

👀 [Preview Link](https://61704f8df1bb4306a7dcc568105fcd73-orbit-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>61704f8df1bb4306a7dcc568105fcd73</projectId>-->
<!--<branchName>orbit-home</branchName>-->